### PR TITLE
Feature/oops 4650/modify formatter logic

### DIFF
--- a/PoorMansTSqlFormatterLibShared/Formatters/TSqlStandardFormatter.cs
+++ b/PoorMansTSqlFormatterLibShared/Formatters/TSqlStandardFormatter.cs
@@ -160,12 +160,7 @@ namespace PoorMansTSqlFormatterLib.Formatters
         private void ProcessSqlNode(Node contentElement, TSqlStandardFormattingState state)
         {
             int initialIndent = state.IndentLevel;
-            if (contentElement.TextValue.Equals("DATEADD"))
-            {
-              Console.Write("");
-            }
             
-
             if (contentElement.GetAttributeValue(SqlStructureConstants.ANAME_HASERROR) == "1")
                 state.OpenClass(SqlHtmlConstants.CLASS_ERRORHIGHLIGHT);
             bool addOutputSpace = true; // New

--- a/PoorMansTSqlFormatterLibShared/Formatters/TSqlStandardFormatter.cs
+++ b/PoorMansTSqlFormatterLibShared/Formatters/TSqlStandardFormatter.cs
@@ -24,6 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Text.RegularExpressions;
 using PoorMansTSqlFormatterLib.Interfaces;
 using PoorMansTSqlFormatterLib.ParseStructure;
@@ -159,6 +160,11 @@ namespace PoorMansTSqlFormatterLib.Formatters
         private void ProcessSqlNode(Node contentElement, TSqlStandardFormattingState state)
         {
             int initialIndent = state.IndentLevel;
+            if (contentElement.TextValue.Equals("DATEADD"))
+            {
+              Console.Write("");
+            }
+            
 
             if (contentElement.GetAttributeValue(SqlStructureConstants.ANAME_HASERROR) == "1")
                 state.OpenClass(SqlHtmlConstants.CLASS_ERRORHIGHLIGHT);
@@ -562,6 +568,13 @@ namespace PoorMansTSqlFormatterLib.Formatters
                                 break;
                               }
                               break;
+                            case SqlStructureConstants.ENAME_FUNCTION_PARENS: // This stops the inline functions from getting a line break
+                              switch (contentElement.Name)
+                              {
+                                case SqlStructureConstants.ENAME_EXPRESSION_PARENS:
+                                  break;
+                              }
+                              break;
                             default:
                               state.AddOutputLineBreak();
                               state.Indent(state.IndentLevel);
@@ -615,11 +628,6 @@ namespace PoorMansTSqlFormatterLib.Formatters
 
                     // Close parenthesis 
                     state.AddOutputContent(FormatOperator(")"), SqlHtmlConstants.CLASS_OPERATOR);
-                    // if (recentKey == "WITH")
-                    //{
-                    //  state.AddOutputLineBreak();
-                    //  state.Indent(state.IndentLevel);
-                    //}
                     state.WordSeparatorExpected = true;
                     if (indentAfter && initialIndent != state.IndentLevel) // New
                     {

--- a/PoorMansTSqlFormatterLibShared/Formatters/TSqlStandardFormatter.cs
+++ b/PoorMansTSqlFormatterLibShared/Formatters/TSqlStandardFormatter.cs
@@ -564,11 +564,7 @@ namespace PoorMansTSqlFormatterLib.Formatters
                               }
                               break;
                             case SqlStructureConstants.ENAME_FUNCTION_PARENS: // This stops the inline functions from getting a line break
-                              switch (contentElement.Name)
-                              {
-                                case SqlStructureConstants.ENAME_EXPRESSION_PARENS:
-                                  break;
-                              }
+                              // Dump out here so the default logic below does not execute
                               break;
                             default:
                               state.AddOutputLineBreak();

--- a/PoorMansTSqlFormatterLibShared/Formatters/TSqlStandardFormatter.cs
+++ b/PoorMansTSqlFormatterLibShared/Formatters/TSqlStandardFormatter.cs
@@ -825,14 +825,14 @@ namespace PoorMansTSqlFormatterLib.Formatters
                             break;
                           default:
                             state.AddOutputContent(formattedOutput, SqlHtmlConstants.CLASS_COMMENT);
-                            state.BreakExpected = true;
-                            state.SourceBreakPending = true;
+                            // GRZ state.BreakExpected = true;
+                            // GRZ state.SourceBreakPending = true;
                             break;
                         }
                         break;
                       default:
                         state.AddOutputContent(formattedOutput, SqlHtmlConstants.CLASS_COMMENT);
-                        state.BreakExpected = true;
+                        // GRZ state.BreakExpected = true;
                         state.SourceBreakPending = true;
                         break;
                     } // New end
@@ -1068,7 +1068,10 @@ namespace PoorMansTSqlFormatterLib.Formatters
                     {
                       if (contentElement.PreviousSibling().Name.Equals(SqlStructureConstants.ENAME_COMMENT_SINGLELINE) && state.SourceBreakPending)
                       {
+                        // TODO: If this is a single line comment not at position zero - we get 2 line breaks
                         state.AddOutputLineBreak();
+                        state.SourceBreakPending = false;
+                        // state.BreakExpected = false;
                       }
                     }
                     break;

--- a/PoorMansTSqlFormatterLibShared/Formatters/TSqlStandardFormatter.cs
+++ b/PoorMansTSqlFormatterLibShared/Formatters/TSqlStandardFormatter.cs
@@ -764,13 +764,11 @@ namespace PoorMansTSqlFormatterLib.Formatters
 
                     if (state.SpecialRegionActive == null && contentElement.TextValue.ToUpperInvariant().Contains("[NOFORMAT]"))
                     {
-                        //state.AddOutputLineBreak();
                         state.SpecialRegionActive = SpecialRegionType.NoFormat;
                         state.RegionStartNode = contentElement;
                     }
                     else if (state.SpecialRegionActive == null && contentElement.TextValue.ToUpperInvariant().Contains("[MINIFY]"))
                     {
-                        //state.AddOutputLineBreak();
                         state.SpecialRegionActive = SpecialRegionType.Minify;
                         state.RegionStartNode = contentElement;
                     }
@@ -833,14 +831,11 @@ namespace PoorMansTSqlFormatterLib.Formatters
                             break;
                           default:
                             state.AddOutputContent(formattedOutput, SqlHtmlConstants.CLASS_COMMENT);
-                            // GRZ state.BreakExpected = true;
-                            // GRZ state.SourceBreakPending = true;
                             break;
                         }
                         break;
                       default:
                         state.AddOutputContent(formattedOutput, SqlHtmlConstants.CLASS_COMMENT);
-                        // GRZ state.BreakExpected = true;
                         state.SourceBreakPending = true;
                         break;
                     } // New end
@@ -1079,7 +1074,7 @@ namespace PoorMansTSqlFormatterLib.Formatters
                         // TODO: If this is a single line comment not at position zero - we get 2 line breaks
                         state.AddOutputLineBreak();
                         state.SourceBreakPending = false;
-                        // state.BreakExpected = false;
+                        state.Indent(state.IndentLevel);
                       }
                     }
                     break;

--- a/PoorMansTSqlFormatterLibShared/ObfuscatingKeywordMapping.cs
+++ b/PoorMansTSqlFormatterLibShared/ObfuscatingKeywordMapping.cs
@@ -34,7 +34,7 @@ namespace PoorMansTSqlFormatterLib
             Instance.Add("LEFT OUTER JOIN", "LEFT JOIN");
             Instance.Add("RIGHT OUTER JOIN", "RIGHT JOIN");
             Instance.Add("FULL OUTER JOIN", "FULL JOIN");
-            //Instance.Add("INNER JOIN", "JOIN");
+            Instance.Add("INNER JOIN", "JOIN");
             Instance.Add("TRANSACTION", "TRAN");
             Instance.Add("BEGIN TRANSACTION", "BEGIN TRAN");
             Instance.Add("COMMIT TRANSACTION", "COMMIT TRAN");

--- a/PoorMansTSqlFormatterLibShared/ObfuscatingKeywordMapping.cs
+++ b/PoorMansTSqlFormatterLibShared/ObfuscatingKeywordMapping.cs
@@ -34,7 +34,7 @@ namespace PoorMansTSqlFormatterLib
             Instance.Add("LEFT OUTER JOIN", "LEFT JOIN");
             Instance.Add("RIGHT OUTER JOIN", "RIGHT JOIN");
             Instance.Add("FULL OUTER JOIN", "FULL JOIN");
-            Instance.Add("INNER JOIN", "JOIN");
+            //Instance.Add("INNER JOIN", "JOIN");
             Instance.Add("TRANSACTION", "TRAN");
             Instance.Add("BEGIN TRANSACTION", "BEGIN TRAN");
             Instance.Add("COMMIT TRANSACTION", "COMMIT TRAN");


### PR DESCRIPTION
These updates focus mostly on indentation/line breaks when single line comments are present either "in line" or as a line before a block of code.